### PR TITLE
Update CI to minify PNGs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,5 +32,4 @@ jobs:
         with:
           name: Document
           path: build/default/default.pdf
-``
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,13 +10,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Setup OptiPNG
+        run: sudo apt-get install -y optipng
+      - name: Minify PNG images
+        run: find . -type f -name '*.png' -exec echo "Compressing" {} \; -exec optipng -o2 {} \;
       - uses: actions/cache@v3
         name: Setup Tectonic cache
         with:
           path: ~/.cache/Tectonic
           key: ${{ runner.os }}-tectonic-${{ hashFiles('**/*.tex') }}
           restore-keys: |
-           ${{ runner.os }}-tectonic-
+            ${{ runner.os }}-tectonic-
       - uses: wtfjoke/setup-tectonic@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,3 +32,5 @@ jobs:
         with:
           name: Document
           path: build/default/default.pdf
+``
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,9 @@ name: 'Continuous delivery'
 on: 
   push:
 
+env:
+  COMPRESSION_LEVEL: 0
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,7 +16,10 @@ jobs:
       - name: Setup OptiPNG
         run: sudo apt-get install -y optipng
       - name: Minify PNG images
-        run: find . -type f -name '*.png' -exec echo "Compressing" {} \; -exec optipng -o2 {} \;
+        run: |
+          if [ ${{ env.COMPRESSION_LEVEL }} -gt 0 ]; then
+            find . -type f -name '*.png' -exec echo "Compressing" {} \; -exec optipng -o${{ env.COMPRESSION_LEVEL }} {} \;
+          fi
       - uses: actions/cache@v3
         name: Setup Tectonic cache
         with:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Informatiklernende (EFZ) schliessen Ihre Ausbildung mit einer individuellen prak
 
 [Video zu Github Actions](https://user-images.githubusercontent.com/1105080/217743574-3568e8e8-8c52-4c41-a64a-f60f2adc5172.webm)
 
+### Falls die Bilder "blank" sind
+Es kann sein, dass die Bilder im PDF (nach dem Download) "blank" sind. Das kann eventuell an der Dateigrösse der Bilder liegen. Falls das der Fall ist, kann man in der cd unter `.github/workflows/cd.yml` die `COMPRESSION_LEVEL` Variable anpassen. Die Levels gehen von 0 bis 7. Das kann eventuell das Problem beheben.
+
 ## Werkzeuge
 
 Für die Realisierung der IPA könnten folgende Werkzeuge und Programme nützlich sein:


### PR DESCRIPTION
As seen in [this CI run](https://github.com/aneshodza/ipa-documentation/actions/runs/5177853931) I had the issue that GitHub would just leave bigger images blank. That would look as follows:
<img width="600" alt="image" src="https://github.com/ictorg/ipa-template/assets/75726773/4892a307-6bd0-4322-8f58-976f9b968a33">
Minifying the images fixed that issue, so I thought maybe we add it to the CI. For the moment its on level two, but it goes all the way from zero to seven.
My 2nd idea was, that the default should be level zero and then adding a notice in the readme, that minifying images may be necessary if there are blank images like that one.